### PR TITLE
Fix/new module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Firecrawl Go SDK is a library that allows you to easily scrape and crawl web
 To install the Firecrawl Go SDK, you can
 
 ```bash
-go get github.com/mendableai/firecrawl
+go get github.com/mendableai/firecrawl-go
 ```
 
 ## Usage
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mendableai/firecrawl/firecrawl"
+	"github.com/mendableai/firecrawl-go"
 )
 
 func main() {

--- a/firecrawl_test.go
+++ b/firecrawl_test.go
@@ -16,7 +16,7 @@ var API_URL string
 var TEST_API_KEY string
 
 func init() {
-	err := godotenv.Load("../.env")
+	err := godotenv.Load()
 	if err != nil {
 		log.Fatalf("Error loading .env file: %v", err)
 	}


### PR DESCRIPTION
# Description

Firecrawl go-sdk is updated [here](https://github.com/mendableai/firecrawl/pull/537)
This PR updates the go-sdk package name in README and update test to use default .env location

## Issue reference

Please reference the issue this PR will close: #1 