### PR TITLE
Fix: Correct module path for v2 to follow Go module versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mendableai/firecrawl-go/v2.1.0
+module github.com/mendableai/firecrawl-go/v2
 
 go 1.22.5
 


### PR DESCRIPTION
## Description

This PR fixes the module path in `go.mod` to follow Go module versioning conventions.

## Problem

The module path was incorrectly set to `github.com/mendableai/firecrawl-go/v2.1.0` which violates Go module versioning rules. This causes the following error when trying to use v2.2.0:

```
go: github.com/mendableai/firecrawl-go/v2@v2.2.0: invalid version: go.mod has non-.../v2 module path "github.com/mendableai/firecrawl-go/v2.1.0" (and .../v2/go.mod does not exist) at revision v2.2.0
```

## Solution

Changed the module path to `github.com/mendableai/firecrawl-go/v2` which is the correct format for v2 modules according to [Go module versioning](https://go.dev/ref/mod#major-version-suffixes).

## Impact

This fix will allow users to properly import and use v2.2.0 and future v2.x.x versions of the library.

## Testing

- Ran `go mod tidy` successfully after the change
- The module now follows proper Go versioning conventions